### PR TITLE
Ottimizza caratteri note aggiuntive

### DIFF
--- a/resources/views/dashboard/upload.blade.php
+++ b/resources/views/dashboard/upload.blade.php
@@ -345,8 +345,7 @@ function chatUploadFlow() {
                    this.meetingDetails.startTime && 
                    this.meetingDetails.endTime && 
                    this.checkTimeValidity() &&
-                   this.odvMembers.some(m => m.name && m.role) &&
-                   this.notesContent.length >= 100;
+                   this.odvMembers.some(m => m.name && m.role);
         },
         
         // Format functions
@@ -1121,7 +1120,6 @@ function chatUploadFlow() {
                         <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center mt-4 gap-4">
                             <p class="text-sm text-gray-500">
                                 <span x-text="notesCharCount"></span> caratteri
-                                <span x-show="notesCharCount < 100" class="text-red-500">(minimo 100 per un verbale completo)</span>
                             </p>
                             <button type="button" 
                                 @click="confirmNotes()"


### PR DESCRIPTION
Remove the minimum character requirement for the 'Note Aggiuntive' field to allow users to confirm notes without a minimum length.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3333d50-b63e-42e6-be88-7ac64574493c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3333d50-b63e-42e6-be88-7ac64574493c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

